### PR TITLE
Fixed typo on example of using sed

### DIFF
--- a/_episodes/05-functions-and-external-tools.md
+++ b/_episodes/05-functions-and-external-tools.md
@@ -412,7 +412,7 @@ for example:
 - Delete a specific line:
 
   ```bash
-  $ sed -n '10p' file.txt
+  $ sed -n '10d' file.txt
   ```
 
 - Appending text after a line. 


### PR DESCRIPTION
In the example for "Delete a specific line" about the `sed` command, there is a typo using `10p` instead of `10d`.